### PR TITLE
Standardize script conventions and extend git-lastdiff capabilities

### DIFF
--- a/src/git-issue2pr.sh
+++ b/src/git-issue2pr.sh
@@ -1,29 +1,85 @@
 #!/bin/bash
+# -----------------------------------------------------------------------------
+# Author: RyoNakagami
+# Revised: 2026-04-23
+# Script: git-issue2pr.sh
+# Description:
+#   Converts an existing GitHub issue into a Pull Request by calling the
+#   GitHub REST API via `gh api`. The current branch is used as the head
+#   branch and the issue is linked as the PR body/source.
+#
+#   Steps:
+#     1. Parse command-line arguments for base branch, issue number, and remote.
+#     2. Resolve owner/repo from the specified git remote URL.
+#     3. Show a confirmation prompt summarizing the PR to be created.
+#     4. Call `gh api repos/<owner>/<repo>/pulls` with head/base/issue fields.
+#
+# Options:
+#    -b <base-branch>   Base branch for the Pull Request (required)
+#    -i <issue-number>  GitHub issue number to convert (required)
+#    -r <remote>        Remote name to resolve owner/repo (default: origin)
+#    -h, --help         Show this help message
+#
+# Usage:
+#   ./git-issue2pr.sh -b main -i 42
+#   ./git-issue2pr.sh -b develop -i 7 -r upstream
+#
+# Notes:
+#   - Requires `gh` CLI authenticated against the target repository.
+#   - Must be run from within a git repository whose remote points to GitHub.
+#   - The current branch is used as the PR head; push it to the remote first.
+# -----------------------------------------------------------------------------
+
 set -euo pipefail
 
-usage() {
-  echo "Usage: $0 -b <base-branch> -i <issue-number> -r <remote>"
-  exit 1
-}
+# ---- Load dependencies ----
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/docstring.sh"
 
-# --- parse args ---
+# ---- Process command line arguments ----
 BASE=""
 ISSUE=""
 REMOTE="origin"
-while getopts ":b:i:r:" opt; do
+
+# Handle long-form help before getopts (getopts doesn't support --help).
+for arg in "$@"; do
+  case "$arg" in
+    -h|--help)
+      usage_helper
+      exit 0
+      ;;
+  esac
+done
+
+while getopts ":b:i:r:h" opt; do
   case $opt in
     b) BASE="$OPTARG" ;;
     i) ISSUE="$OPTARG" ;;
     r) REMOTE="$OPTARG" ;;
-    *) usage ;;
+    h)
+      usage_helper
+      exit 0
+      ;;
+    \?)
+      echo "Error: Unknown option -$OPTARG"
+      usage_helper
+      exit 1
+      ;;
+    :)
+      echo "Error: Option -$OPTARG requires an argument"
+      usage_helper
+      exit 1
+      ;;
   esac
 done
 
+# ---- Input Validation ----
 if [[ -z "$BASE" || -z "$ISSUE" ]]; then
-  usage
+  echo "Error: -b <base-branch> and -i <issue-number> are required."
+  usage_helper
+  exit 1
 fi
 
-# --- get repo owner/name from git remote ---
+# ---- Resolve owner/repo from remote URL ----
 REMOTE_URL=$(git remote get-url "$REMOTE")
 if [[ "$REMOTE_URL" =~ github.com[:/](.+)/(.+)\.git ]]; then
   OWNER="${BASH_REMATCH[1]}"
@@ -33,10 +89,10 @@ else
   exit 1
 fi
 
-# --- get current branch ---
+# ---- Current branch ----
 HEAD_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
-# --- confirmation prompt ---
+# ---- Confirmation prompt ----
 echo "⚡ Ready to create a Pull Request:"
 echo "  Repo:   $OWNER/$REPO"
 echo "  Head:   $HEAD_BRANCH"
@@ -50,8 +106,10 @@ if [[ ! "$CONFIRM" =~ ^[Yy]$ ]]; then
   exit 1
 fi
 
-# --- create PR ---
+# ---- Create PR ----
 gh api "repos/$OWNER/$REPO/pulls" \
   -f "head=$HEAD_BRANCH" \
   -f "base=$BASE" \
   -F "issue=$ISSUE"
+
+echo "🎉 Done."

--- a/src/git-lastdiff.sh
+++ b/src/git-lastdiff.sh
@@ -1,64 +1,127 @@
 #!/bin/bash
-## git difftool
-## Author: Ryo Nakagami
-## Revised: 2024-12-17
-## REQUIREMENT
+# -----------------------------------------------------------------------------
+# Author: Ryo Nakagami
+# Revised: 2026-04-23
+# Script: git-lastdiff.sh
+# Description:
+#   Shows the diff introduced by the most recent commit that touched a given
+#   file, compared against the current HEAD.
+#
+#   Steps:
+#     1. Validate input and confirm the target file exists inside a git repo.
+#     2. Locate the N-th most recent commit that modified the file (default 1).
+#     3. Resolve its parent, falling back to the empty tree for root commits.
+#     4. Launch `git difftool` (or `git diff` with --no-tool) between that
+#        parent and HEAD, scoped to the file.
+#
+# Options:
+#    -n <N>          Use the N-th most recent commit touching the file (default: 1)
+#    --no-tool       Use `git diff` instead of `git difftool`
+#    -h, --help      Show this help message
+#
+# Usage:
+#   ./git-lastdiff.sh <file path>
+#   ./git-lastdiff.sh <file path> -n 2          # second-to-last change
+#   ./git-lastdiff.sh <file path> --no-tool     # plain git diff output
+#
+# Notes:
+#   - Requires git to be installed and configured.
+#   - Must be run from within a git repository.
+#   - `git difftool` honors your configured diff.tool.
+# -----------------------------------------------------------------------------
 
-set -eu
+set -euo pipefail
 
-# Function to display usage information
-function usage {
-    cat <<EOM
-NAME
-    $(basename "$0")
-        This script uses git difftool to show the differences between the last commit and the 
-        current state of the specified file.
+# ---- Load dependencies ----
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/docstring.sh"
 
-Syntax
-    $(basename "$0") <folder path>
+# ---- Process command line arguments ----
+TARGET_FILE=""
+COMMIT_OFFSET=1
+USE_TOOL=true
 
-EOM
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -n)
+            if [[ $# -lt 2 || -z "${2:-}" ]]; then
+                echo "Error: -n requires a positive integer argument"
+                usage_helper
+                exit 1
+            fi
+            COMMIT_OFFSET=$2
+            shift 2
+            ;;
+        --no-tool)
+            USE_TOOL=false
+            shift
+            ;;
+        -h|--help)
+            usage_helper
+            exit 0
+            ;;
+        -*)
+            echo "Error: Unknown option $1"
+            usage_helper
+            exit 1
+            ;;
+        *)
+            if [[ -n "$TARGET_FILE" ]]; then
+                echo "Error: Unexpected extra argument '$1'"
+                usage_helper
+                exit 1
+            fi
+            TARGET_FILE=$1
+            shift
+            ;;
+    esac
+done
 
-    exit 1
-}
-
-
-
-# Function to check if a file exists
-check_file_exists() {
-  local file="$1"
-  if [[ ! -f "$file" ]]; then
-    echo "File '$file' does not exist."
-    exit 1
-  fi
-}
-
-# Function to fetch commit ID
-fetch_commitid() {
-  local file="$1"
-  COMMIT_ID=$(git log --format="%H" -n 1 -- "$file")
-  if [[ -z "$COMMIT_ID" ]]; then
-    echo "Failed to fetch commit ID for '$file'."
-    exit 1
-  fi
-  echo "$COMMIT_ID"
-}
-
-# arg check
-if [[ $# -eq 0 ]]; then
-  usage
-fi
-
-TARGET_FILE="$1"
-
+# ---- Input Validation ----
 if [[ -z "$TARGET_FILE" ]]; then
-  echo "Error: TARGET_FILE is empty."
-  exit 1
+    echo "Error: Missing file path."
+    usage_helper
+    exit 1
 fi
 
-check_file_exists "$TARGET_FILE"
+if ! [[ "$COMMIT_OFFSET" =~ ^[1-9][0-9]*$ ]]; then
+    echo "Error: -n must be a positive integer (got '$COMMIT_OFFSET')."
+    exit 1
+fi
 
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "❌ Not inside a git repository."
+    exit 1
+fi
 
-# main
-COMMIT_ID=$(fetch_commitid "$TARGET_FILE")
-git difftool -y "$COMMIT_ID~1" HEAD -- "$TARGET_FILE"
+if [[ ! -f "$TARGET_FILE" ]]; then
+    echo "❌ File '$TARGET_FILE' does not exist."
+    exit 1
+fi
+
+# ---- Resolve commit that last touched the file ----
+COMMIT_ID=$(git log --format="%H" -n "$COMMIT_OFFSET" -- "$TARGET_FILE" | tail -n 1)
+
+if [[ -z "$COMMIT_ID" ]]; then
+    echo "❌ No commit history found for '$TARGET_FILE'."
+    exit 1
+fi
+
+COMMIT_COUNT=$(git log --format="%H" -- "$TARGET_FILE" | wc -l)
+if (( COMMIT_OFFSET > COMMIT_COUNT )); then
+    echo "❌ Requested commit #$COMMIT_OFFSET but '$TARGET_FILE' only has $COMMIT_COUNT commit(s)."
+    exit 1
+fi
+
+# Resolve parent; fall back to empty tree hash for root commits.
+if PARENT_ID=$(git rev-parse --verify "${COMMIT_ID}^" 2>/dev/null); then
+    :
+else
+    PARENT_ID=$(git hash-object -t tree /dev/null)
+fi
+
+# ---- Execute diff ----
+if $USE_TOOL; then
+    git difftool -y "$PARENT_ID" HEAD -- "$TARGET_FILE"
+else
+    git diff "$PARENT_ID" HEAD -- "$TARGET_FILE"
+fi

--- a/src/git-sparse-checkout.sh
+++ b/src/git-sparse-checkout.sh
@@ -1,33 +1,97 @@
 #!/bin/bash
+# -----------------------------------------------------------------------------
+# Author: RyoNakagami
+# Revised: 2026-04-23
+# Script: git-sparse-checkout.sh
+# Description:
+#   Performs a sparse checkout of a remote git repository, cloning only the
+#   specified paths (or, in bare mode, just the top-level files and empty
+#   directory skeleton).
+#
+#   Steps:
+#     1. Parse command-line arguments for clone URL, target dir, branch,
+#        sparse path list, and bare-mode flag.
+#     2. Clone the repository with blob filtering and no checkout.
+#     3. Enable core.sparseCheckout and write the sparse-checkout rules.
+#     4. Checkout the requested branch; in bare mode, materialize empty dirs.
+#
+# Options:
+#    -u <clone_url>     Git URL to clone (required)
+#    -d <target_dir>    Local target directory (required)
+#    -b <branch>        Branch to checkout (required)
+#    -p <sparse_path>   Colon-separated list of sparse paths
+#                       (required unless -s)
+#    -s                 Bare mode: fetch only top-level files plus an empty
+#                       directory skeleton (no -p required)
+#    -h, --help         Show this help message
+#
+# Usage:
+#   ./git-sparse-checkout.sh -u git@github.com:owner/repo.git \
+#                            -d ./repo -b main -p "src/a:docs"
+#   ./git-sparse-checkout.sh -u git@github.com:owner/repo.git \
+#                            -d ./repo -b main -s
+#
+# Notes:
+#   - Requires git >= 2.25 with sparse-checkout support.
+#   - Sparse paths in -p are separated by ':'.
+# -----------------------------------------------------------------------------
+
 set -euo pipefail
 
-usage() {
-  echo "Usage: $0 -u <clone_url> -d <target_dir> -b <branch> -p <sparse_path> -s"
-  exit 1
-}
+# ---- Load dependencies ----
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/docstring.sh"
 
+# ---- Process command line arguments ----
 BARE=false
 
-while getopts "su:d:b:p:" opt; do
+# Handle long-form help before getopts (getopts doesn't support --help).
+for arg in "$@"; do
+  case "$arg" in
+    -h|--help)
+      usage_helper
+      exit 0
+      ;;
+  esac
+done
+
+while getopts ":su:d:b:p:h" opt; do
   case $opt in
-    s) BARE=true ;; 
+    s) BARE=true ;;
     u) CLONE_URL=$OPTARG ;;
     d) TARGET_DIR=$OPTARG ;;
     b) BRANCH=$OPTARG ;;
     p) SPARSE_PATH=$OPTARG ;;
-    *) usage ;;
+    h)
+      usage_helper
+      exit 0
+      ;;
+    \?)
+      echo "Error: Unknown option -$OPTARG"
+      usage_helper
+      exit 1
+      ;;
+    :)
+      echo "Error: Option -$OPTARG requires an argument"
+      usage_helper
+      exit 1
+      ;;
   esac
 done
 
+# ---- Input Validation ----
 if [[ -z "${CLONE_URL-}" || -z "${TARGET_DIR-}" || -z "${BRANCH-}" ]]; then
-  usage
+  echo "Error: -u, -d, and -b are required."
+  usage_helper
+  exit 1
 fi
 
 if [[ "$BARE" = false && -z "${SPARSE_PATH-}" ]]; then
   echo "Error: -p <sparse_path> is required unless -s (bare mode) is specified."
-  usage
+  usage_helper
+  exit 1
 fi
 
+# ---- Clone and configure sparse checkout ----
 git clone --filter=blob:none --no-checkout "$CLONE_URL" "$TARGET_DIR"
 cd "$TARGET_DIR"
 git config core.sparseCheckout true
@@ -39,8 +103,10 @@ if $BARE; then
   } > .git/info/sparse-checkout
   git checkout "$BRANCH"
   git ls-tree -r -d --name-only HEAD | xargs -I{} mkdir -p "{}"
+  echo "🎉 Done."
   exit 0
 fi
 
 echo -e "$SPARSE_PATH" | tr ':' '\n' > .git/info/sparse-checkout
 git checkout "$BRANCH"
+echo "🎉 Done."

--- a/src/git-tmp-checkout.sh
+++ b/src/git-tmp-checkout.sh
@@ -1,35 +1,92 @@
 #!/bin/bash
+# -----------------------------------------------------------------------------
+# Author: RyoNakagami
+# Revised: 2026-04-23
+# Script: git-tmp-checkout.sh
+# Description:
+#   Snapshots the current working tree (including untracked files) into a
+#   stash, creates a new branch, and re-applies the stash on top of it so
+#   in-progress work can be moved off the current branch without losing state.
+#
+#   Steps:
+#     1. Parse command-line arguments for stash message and new branch name.
+#     2. `git stash push -a` to capture tracked + untracked changes.
+#     3. `git switch -c` to create and switch to the new branch.
+#     4. `git stash apply stash@{0}` to restore the working tree on the new branch.
+#
+# Options:
+#    -m <stash_message>   Message to attach to the stash
+#                         (default: timestamp + short commit id)
+#    -c <new_branch>      Name of the new branch to create (required)
+#    -h, --help           Show this help message
+#
+# Usage:
+#   ./git-tmp-checkout.sh -c feature/wip
+#   ./git-tmp-checkout.sh -m "wip: refactor" -c feature/wip
+#
+# Notes:
+#   - Requires git with `switch` support (git >= 2.23).
+#   - The stash is left in the stash list after apply; drop it manually if
+#     you no longer need the snapshot.
+# -----------------------------------------------------------------------------
 
-# Function to display usage information
-usage() {
-    echo "Usage: $0 -m <stash_message> -c <new_branch_name>"
-    exit 1
-}
+set -euo pipefail
 
-# Parse command-line arguments
-while getopts "m:c:" opt; do
-    case "$opt" in
-        m) stash_message="$OPTARG" ;;
-        c) new_branch_name="$OPTARG" ;;
-        *) usage ;;
+# ---- Load dependencies ----
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/docstring.sh"
+
+# ---- Process command line arguments ----
+stash_message=""
+new_branch_name=""
+
+# Handle long-form help before getopts (getopts doesn't support --help).
+for arg in "$@"; do
+    case "$arg" in
+        -h|--help)
+            usage_helper
+            exit 0
+            ;;
     esac
 done
 
-# Check if the branch name is provided
+while getopts ":m:c:h" opt; do
+    case "$opt" in
+        m) stash_message="$OPTARG" ;;
+        c) new_branch_name="$OPTARG" ;;
+        h)
+            usage_helper
+            exit 0
+            ;;
+        \?)
+            echo "Error: Unknown option -$OPTARG"
+            usage_helper
+            exit 1
+            ;;
+        :)
+            echo "Error: Option -$OPTARG requires an argument"
+            usage_helper
+            exit 1
+            ;;
+    esac
+done
+
+# ---- Input Validation ----
 if [ -z "$new_branch_name" ]; then
-    usage
+    echo "Error: -c <new_branch> is required."
+    usage_helper
+    exit 1
 fi
 
-# Use a default message if -m is empty
+# ---- Default stash message ----
 if [ -z "$stash_message" ]; then
     timestamp=$(date +"%Y-%m-%d %H:%M:%S")
     commit_id=$(git rev-parse --short HEAD 2>/dev/null || echo "no-commit-id")
     stash_message="Stash created on $timestamp from commit $commit_id"
 fi
 
-# Command sequence
+# ---- Execute ----
 git stash push -a -m "$stash_message" &&
 git switch -c "$new_branch_name" &&
 git stash apply stash@{0}
 
-echo "Successfully switched to branch '$new_branch_name' and applied stashed changes."
+echo "🎉 Successfully switched to branch '$new_branch_name' and applied stashed changes."

--- a/src/git-tree.sh
+++ b/src/git-tree.sh
@@ -1,82 +1,85 @@
 #!/bin/bash
-## Tree-display git-tracked files
-## Author: Ryo Nakagami
-## Revised: 2024-12-19
-## REQUIREMENT: tree command
+# -----------------------------------------------------------------------------
+# Author: Ryo Nakagami
+# Revised: 2026-04-23
+# Script: git-tree.sh
+# Description:
+#   Tree-display for git-tracked files. Wraps `tree --fromfile` so the output
+#   respects .gitignore and only shows files that git knows about.
+#
+#   Steps:
+#     1. Confirm we are inside a git working tree (scoped to the target path
+#        when one is supplied).
+#     2. List git-tracked files via `git ls-tree -r --name-only HEAD`.
+#     3. Pipe the list into `tree --fromfile` to render the hierarchy.
+#
+# Options:
+#    -h, --help     Show this help message
+#
+# Usage:
+#   ./git-tree.sh                 # render the entire repository
+#   ./git-tree.sh <folder path>   # render only the given folder
+#
+# Notes:
+#   - Requires git and the `tree` command to be installed.
+#   - Must be run from within a git repository.
+#   - When the given folder is not tracked by git, the output will be empty:
+#       <folder name>
+#
+#       0 directories, 0 files
+# -----------------------------------------------------------------------------
 
-function usage {
-    cat <<EOM
-NAME
-    $(basename "$0") - Lists the contents of a given tree object, like what "/bin/tree" does in the current git working directory.
+set -euo pipefail
 
-Syntax
-    $(basename "$0") <folder path>
+# ---- Load dependencies ----
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/docstring.sh"
 
-DESCRIPTION
-    This is a wrapper function of tree. 
-    You need to install tree command in advance.
-    
-    When your current directory is a git-tracked folder, this allows you to show files that are not ignored in .gitignore.
-    When you specify a directory which is not tracked by git as an input, gtree returns 
-        <folder name>
-        
-        0 directories, 0 files
+# ---- Process command line arguments ----
+TARGET_DIR=""
 
-    When your current directory is not a git-tracked one, this returns the following error:
-        <folder name>
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--help)
+            usage_helper
+            exit 0
+            ;;
+        -*)
+            echo "Error: Unknown option $1"
+            usage_helper
+            exit 1
+            ;;
+        *)
+            if [[ -n "$TARGET_DIR" ]]; then
+                echo "Error: Unexpected extra argument '$1'"
+                usage_helper
+                exit 1
+            fi
+            TARGET_DIR=$1
+            shift
+            ;;
+    esac
+done
 
-        0 directories, 0 files
-        fatal: not a git repository (or any of the parent directories): .git
-    
-OPTIONS
-  -h, --help
-    Display help
-
-EOM
-
-    exit 0
-}
-
-function error_message {
-    echo 'fatal: something wrong! Check the input. Possibly your input is not a direcotry'
+# ---- Input Validation ----
+if ! command -v tree >/dev/null 2>&1; then
+    echo "❌ 'tree' command not found. Please install it first."
     exit 1
-}
+fi
 
-function directory_error_message {
-    echo 'fatal: $1 does not exist. Check the folder input'
+if [[ -n "$TARGET_DIR" && ! -d "$TARGET_DIR" ]]; then
+    echo "❌ '$TARGET_DIR' does not exist or is not a directory."
     exit 1
-}
+fi
 
-function not_git_repository_error {
+GIT_CHECK_DIR="${TARGET_DIR:-.}"
+if ! git -C "$GIT_CHECK_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     echo "fatal: not a git repository (or any of the parent directories): .git"
     exit 1
-}
+fi
 
-
-if [[ $1 == '-h' || $1 == '--help' ]]; then
-    usage
-    exit 1
-fi 
-
-if [[ $# == 0 ]]; then
-    # git-managed chaeck
-    if ! git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
-      not_git_repository_error
-    fi
-
+# ---- Execute tree rendering ----
+if [[ -z "$TARGET_DIR" ]]; then
     git ls-tree -r --name-only HEAD | tree --fromfile
-    exit 0
-
-elif [[ $# == 1 ]]; then
-    if [ -d $1 ]; then
-        # git-managed chaeck
-        if ! git -C "$1" rev-parse --is-inside-work-tree > /dev/null 2>&1; then
-            not_git_repository_error
-        fi
-        git ls-tree -r --name-only HEAD $1 | tree --fromfile
-    else
-        directory_error_message
-    fi
 else
-    error_message
+    git ls-tree -r --name-only HEAD "$TARGET_DIR" | tree --fromfile
 fi


### PR DESCRIPTION
## Summary
- Standardize headers, `--help` handling, and `usage_helper` integration across `git-issue2pr`, `git-sparse-checkout`, `git-tmp-checkout`, and `git-tree` for a consistent CLI surface.
- Extend `git-lastdiff` with `-n <offset>` to diff against an arbitrary prior commit, a `--no-tool` flag to bypass the configured difftool, and safe handling of the root commit.

## Changes
| File | Notes |
| --- | --- |
| `src/git-issue2pr.sh` | Header/help/usage_helper standardization |
| `src/git-sparse-checkout.sh` | Header/help/usage_helper standardization |
| `src/git-tmp-checkout.sh` | Header/help/usage_helper standardization |
| `src/git-tree.sh` | Header/help/usage_helper standardization |
| `src/git-lastdiff.sh` | `-n` offset, `--no-tool`, root-commit handling |

## Commits
- `e82d15e` ENH: git-lastdiff supports -n offset, --no-tool flag, and root-commit handling
- `9c73ce0` REFACTOR: standardize script headers, help handling, and usage_helper integration across git-issue2pr, git-sparse-checkout, git-tmp-checkout, and git-tree

## Test plan
- [ ] `git issue2pr --help`, `git sparse-checkout --help`, `git tmp-checkout --help`, `git tree --help` render via `usage_helper`
- [ ] `git lastdiff -n 2` shows diff against `HEAD~2`
- [ ] `git lastdiff --no-tool` prints to stdout instead of launching the difftool
- [ ] `git lastdiff` on a repo with a single (root) commit exits cleanly